### PR TITLE
Add Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # k8nskel
 
-TODO: Add Travis CI badge
+[![Build Status](https://travis-ci.org/wantedly/k8nskel.svg?branch=master)](https://travis-ci.org/wantedly/k8nskel)
 
 Kubernetes Controller to distribute Secrets to new Namespace on Kubernetes.
 


### PR DESCRIPTION
## WHY

- Make the build status of Travis CI visible with a badge.

## WHAT

- Add Travis CI badge to README.
