### PR TITLE
Support excluding specific Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Docker image is available at [`quay.io/wantedly/k8nskel`](https://quay.io/reposi
 |-|-|-|
 |K8NSKEL_ORIGIN|Name of the namespace from which the secret is copied.|"k8nskel-origin"|
 |K8NSKEL_IGNORE_DEST|CSV list of namespaces that does not reflect secrets in `K8NSKEL_ORIGIN` is added/modified/deleted. It is not reflected in `K8NSKEL_ORIGIN` by default.|"kube-public,kube-system"|
+|K8NSKEL_EXCLUDE_SECRETS|CSV list of secrets that does not reflect secrets in `K8NSKEL_ORIGIN` is added/modified/deleted. If this value empty, k8nskell sync all secrets in `K8NSKEL_ORIGIN` |""|
 
 ## Usage
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,13 @@ const (
 
 	// defaultTokenPrefix is prefix of default token in secret
 	defaultTokenPrefix = "default-token-"
+
+	// ignoreSecretsEnvKey is key of the environment variable that contains excluding Secrets.
+	// the value expects a comma-separated list of Secret names.
+	excludeSecretsEnvKey = "K8NSKEL_EXCLUDE_SECRETS"
+
+	// defaultExcludeSecrets is default value of excluding Secrets list.
+	defaultExcludeSecrets = ""
 )
 
 func main() {
@@ -34,7 +41,13 @@ func main() {
 		k8nskelIgnoreDest = v
 	}
 
-	client, err := newClient(k8nskelOrigin, k8nskelIgnoreDest)
+	// Get exclude Secret lists from environment value
+	excludeSecrets := defaultExcludeSecrets
+	if v, ok := os.LookupEnv("K8NSKEL_EXCLUDE_SECRETS"); ok {
+		excludeSecrets = v
+	}
+
+	client, err := newClient(k8nskelOrigin, k8nskelIgnoreDest, excludeSecrets)
 	if err != nil {
 		log.Fatalf("failed to initialize Kubernetes API client: %s", err)
 	}


### PR DESCRIPTION
## WHY

Currently, k8nskel syncs all Secrets in the `K8NSKEL_ORIGIN` namespace. But this behavior contains the risk of overwritten important Secret unintendedly.

## WHAT

This PR allows users to define the list of Secrets via the `K8NSKEL_EXCLUDE_SECRETS` environment variable and k8nskel doesn't sync a Secret if contains this list.