### PR TITLE
Bump Go version to 1.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
 cache:
   directories:
-    - vendor
+  - $GOPATH/pkg/mod
 
 install:
   - make deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - '1.9'
+  - '1.17'
 
 services:
   - docker


### PR DESCRIPTION
## RELATED ISSUES

#9 

## WHY

This project uses Go 1.9 in Travis CI. But the latest Go version is 1.17.7. Using old runtime is too bad for many reasons (security risks, maintenancability, performance, and more...). So we need to update Go version.

## WHAT

I updated the Go version 1.17 in Travis CI.
